### PR TITLE
HA-5 Backend : 공고 Entity 설계

### DIFF
--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Animal.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Animal.java
@@ -1,0 +1,35 @@
+package com.jeonggolee.helpanimal.domain.recruitment.entity;
+
+import com.jeonggolee.helpanimal.common.eneity.BaseTimeEntity;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Animal extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    /**
+     * 이름 ( 개, 고양이, 사자, 호랑이, 낙타, 타조 등등)
+     */
+
+    @Column(nullable = false, unique = true, length = 10)
+    private String name;
+
+    /**
+     * 등록자
+     */
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public void updateAnimalName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Recruitment.java
@@ -1,0 +1,68 @@
+package com.jeonggolee.helpanimal.domain.recruitment.entity;
+
+import com.jeonggolee.helpanimal.common.eneity.BaseTimeEntity;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Recruitment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 공고명 */
+    @Column(nullable = false, length = 30)
+    private String name;
+
+    /** 공고 구분(일회성, 크루 충원) */
+    @Column
+    @Enumerated(EnumType.STRING)
+    private RecruitmentType recruitmentType;
+
+    /** 등록자 */
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    /** 내용 */
+    @Column(nullable = false)
+    private String content;
+
+    /** 봉사 구분 (개, 고양이 등등) */
+    @OneToOne
+    @JoinColumn(name = "animal_type")
+    private Animal animal;
+
+    /** 총 참가 인원 */
+    @Column(nullable = false)
+    private int participant;
+
+    /** 첨부 이미지 */
+    @Column(nullable = false, length = 500)
+    private String imageUrl;
+
+    /** 채용 방식 */
+    @Column
+    @Enumerated(EnumType.STRING)
+    private RecruitmentMethod recruitmentMethod;
+
+    /** 공고신청내역 */
+    @OneToMany(mappedBy = "recruitment")
+    private List<RecruitmentApplicationDetail> recruitmentApplicationDetails;
+
+    public void updateRecruitmentName(String name) {
+        this.name = name;
+    }
+
+
+
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/RecruitmentApplicationDetail.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/RecruitmentApplicationDetail.java
@@ -1,0 +1,36 @@
+package com.jeonggolee.helpanimal.domain.recruitment.entity;
+
+import com.jeonggolee.helpanimal.common.eneity.BaseTimeEntity;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class RecruitmentApplicationDetail extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "recruitment_id")
+    private Recruitment recruitment;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 50, nullable = false)
+    private String comment;
+
+    public void updateComment(String comment) {
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/enums/RecruitmentMethod.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/enums/RecruitmentMethod.java
@@ -1,0 +1,8 @@
+package com.jeonggolee.helpanimal.domain.recruitment.enums;
+
+public enum RecruitmentMethod {
+    /**
+     * 선착순, 선택
+     */
+    FIRST_COME, CHOICE
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/enums/RecruitmentType.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/enums/RecruitmentType.java
@@ -1,0 +1,5 @@
+package com.jeonggolee.helpanimal.domain.recruitment.enums;
+
+public enum RecruitmentType {
+    FREE, CREW
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepository.java
@@ -1,0 +1,10 @@
+package com.jeonggolee.helpanimal.domain.recruitment.repository;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Animal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AnimalRepository extends JpaRepository<Animal,Long> {
+    public Optional<Animal> findByName(String name);
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentApplicationDetailRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentApplicationDetailRepository.java
@@ -1,0 +1,7 @@
+package com.jeonggolee.helpanimal.domain.recruitment.repository;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplicationDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitmentApplicationDetailRepository extends JpaRepository<RecruitmentApplicationDetail, Long> {
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,0 +1,10 @@
+package com.jeonggolee.helpanimal.domain.recruitment.repository;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+    public Optional<Recruitment> findByName(String name);
+}

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepositoryTest.java
@@ -1,0 +1,122 @@
+package com.jeonggolee.helpanimal.domain.recruitment.repository;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Animal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+public class AnimalRepositoryTest {
+    @Autowired
+    private AnimalRepository animalRepository;
+
+    private static final String name = "개";
+
+    private Animal initEntity() {
+        return Animal.builder()
+                .name(name)
+                .build();
+    }
+
+    @Test
+    @DisplayName("동물 등록")
+    void 동물등록() {
+        //given
+        Animal animal = initEntity();
+
+        //when
+        Long id = animalRepository.save(animal).getId();
+
+        //then
+        assertThat(animalRepository.findById(id).isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("동물 ID로 조회")
+    void 동물ID로_조회() {
+        //given
+        Animal animal = initEntity();
+        Long id = animalRepository.save(animal).getId();
+
+        //when
+        Optional<Animal> findAnimal = animalRepository.findById(id);
+
+        //then
+        assertThat(findAnimal.isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("동물 ID로 조회 실패")
+    void 동물ID로_조회_실패() {
+        //given
+        Long id = 1000L;
+
+        //when
+        Optional<Animal> animal = animalRepository.findById(id);
+
+        //then
+        assertThat(animal.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("동물명 조회")
+    void 동물명으로_조회() {
+        //given
+        Animal animal = initEntity();
+        animalRepository.save(animal);
+
+        //when
+        Optional<Animal> findAnimal = animalRepository.findByName(name);
+
+        //then
+        assertThat(findAnimal.isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("동물명으로 조회 실패")
+    void 동물명으로_조회_실패() {
+        //given
+
+        //when
+        Optional<Animal> animal = animalRepository.findByName("테스트실패");
+
+        //then
+        assertThat(animal.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("동물 수정")
+    void 동물수정() {
+        //given
+        Animal animal = initEntity();
+        animalRepository.save(animal);
+
+        //when
+        animal.updateAnimalName("수정");
+        Animal updateAnimal = animalRepository.save(animal);
+
+        //then
+        assertThat(updateAnimal.getName()).isEqualTo(animal.getName());
+    }
+
+    @Test
+    @DisplayName("동물 삭제")
+    void 동물삭제() {
+        //given
+        Animal animal = initEntity();
+        Long id = animalRepository.save(animal).getId();
+
+        //when
+        animalRepository.delete(animal);
+
+        //then
+        Optional<Animal> deleteAnimal = animalRepository.findById(id);
+        assertThat(deleteAnimal.isPresent()).isFalse();
+    }
+}

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitApplicationDetailRepositoryTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitApplicationDetailRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.jeonggolee.helpanimal.domain.recruitment.repository;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplicationDetail;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+public class RecruitApplicationDetailRepositoryTest {
+    @Autowired
+    private RecruitmentApplicationDetailRepository recruitmentApplicationDetailRepository;
+
+    private static final String comment = "TEST";
+
+    private RecruitmentApplicationDetail initEntity() {
+        return RecruitmentApplicationDetail.builder()
+                .comment(comment)
+                .build();
+    }
+
+    @Test
+    @DisplayName("공고신청내역 등록")
+    void 공고신청내역등록() {
+        //given
+        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
+
+        //when
+        Long id = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail).getId();
+
+        //then
+        assertThat(recruitmentApplicationDetailRepository.findById(id).isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("공고신청내역 ID로 조회")
+    void 공고신청내역ID로_조회() {
+        //given
+        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
+        Long id = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail).getId();
+
+        //when
+        Optional<RecruitmentApplicationDetail> findRecruitmentApplicationDetail = recruitmentApplicationDetailRepository.findById(id);
+
+        //then
+        assertThat(findRecruitmentApplicationDetail.isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("공고신청내역 ID로 조회 실패")
+    void 공고신청내역ID로_조회_실패() {
+        //given
+        Long id = 1000L;
+
+        //when
+        Optional<RecruitmentApplicationDetail> recruitmentApplicationDetail = recruitmentApplicationDetailRepository.findById(id);
+
+        //then
+        assertThat(recruitmentApplicationDetail.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("공고신청내역 수정")
+    void 공고신청내역수정() {
+        //given
+        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
+        recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail);
+
+        //when
+        recruitmentApplicationDetail.updateComment("수정");
+        RecruitmentApplicationDetail updateRecruitmentApplicationDetail = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail);
+
+        //then
+        assertThat(updateRecruitmentApplicationDetail.getComment()).isEqualTo(updateRecruitmentApplicationDetail.getComment());
+    }
+
+    @Test
+    @DisplayName("공고신청내역 삭제")
+    void 공고신청내역삭제() {
+        //given
+        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
+        Long id = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail).getId();
+
+        //when
+        recruitmentApplicationDetailRepository.delete(recruitmentApplicationDetail);
+
+        //then
+        Optional<RecruitmentApplicationDetail> deleteRecruitmentApplicationDetail = recruitmentApplicationDetailRepository.findById(id);
+        assertThat(deleteRecruitmentApplicationDetail.isPresent()).isFalse();
+    }
+}

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepositoryTest.java
@@ -1,0 +1,138 @@
+package com.jeonggolee.helpanimal.domain.recruitment.repository;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+public class RecruitmentRepositoryTest {
+
+    @Autowired
+    RecruitmentRepository recruitmentRepository;
+
+    private static final String name = "테스트 공고명";
+    private static final RecruitmentType recruitmentType = RecruitmentType.CREW;
+    private static final String content = "테스트 본문";
+    private static final int participant = 11;
+    private static final String imageUrl = "test";
+    private static final RecruitmentMethod recruitmentMethod = RecruitmentMethod.FIRST_COME;
+
+
+    private Recruitment initEntity() {
+        return Recruitment.builder()
+                .name(name)
+                .recruitmentType(recruitmentType)
+                .content(content)
+                .participant(participant)
+                .imageUrl(imageUrl)
+                .recruitmentMethod(recruitmentMethod)
+                .build();
+    }
+
+    @Test
+    @DisplayName("공고 등록")
+    void 공고등록() {
+        //given
+        Recruitment recruitment = initEntity();
+
+        //when
+        Long id = recruitmentRepository.save(recruitment).getId();
+
+        //then
+        assertThat(recruitmentRepository.findById(id).isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("공고 ID로 조회")
+    void 공고ID로_조회() {
+        //given
+        Recruitment recruitment = initEntity();
+        Long id = recruitmentRepository.save(recruitment).getId();
+
+        //when
+        Optional<Recruitment> findRecruitment = recruitmentRepository.findById(id);
+
+        //then
+        assertThat(findRecruitment.isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("공고 ID로 조회 실패")
+    void 공고ID로_조회_실패() {
+        //given
+        Long id = 1L;
+
+        //when
+        Optional<Recruitment> recruitment = recruitmentRepository.findById(id);
+
+        //then
+        assertThat(recruitment.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("공고명 조회")
+    void 공고명으로_조회() {
+        //given
+        Recruitment recruitment = initEntity();
+        recruitmentRepository.save(recruitment);
+
+        //when
+        Optional<Recruitment> findRecruitment = recruitmentRepository.findByName(name);
+
+        //then
+        assertThat(findRecruitment.isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("공고명으로 조회 실패")
+    void 공고명으로_조회_실패() {
+        //given
+
+        //when
+        Optional<Recruitment> recruitment = recruitmentRepository.findByName("테스트실패");
+
+        //then
+        assertThat(recruitment.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("공고 수정")
+    void 공고수정() {
+        //given
+        Recruitment recruitment = initEntity();
+        recruitmentRepository.save(recruitment);
+
+        //when
+        recruitment.updateRecruitmentName("수정");
+        Recruitment updateRecruitment = recruitmentRepository.save(recruitment);
+
+        //then
+        assertThat(updateRecruitment.getName()).isEqualTo(recruitment.getName());
+    }
+
+    @Test
+    @DisplayName("공고 삭제")
+    void 공고삭제() {
+        //given
+        Recruitment recruitment = initEntity();
+        Long id = recruitmentRepository.save(recruitment).getId();
+
+        //when
+        recruitmentRepository.delete(recruitment);
+
+        //then
+        Optional<Recruitment> deleteRecruitment = recruitmentRepository.findById(id);
+        assertThat(deleteRecruitment.isPresent()).isFalse();
+    }
+
+}


### PR DESCRIPTION
HA-5 Backend : 공고 Entity 설계 및 Repository Test Code 추가
* 공고, 공고내역, 동물 Entity 설계
* 동물은 enum으로 관리하려다 저번에 얘기한 것 처럼 유지보수 관리 측면에서 관리자가 등록할 수 있도록 따로 Entity를 빼서 설계했습니다. 문제시 추후 enum으로 수정 가능합니다.