### PR TITLE
HA-24 Backend : 공고 CRUD 구현 

### DIFF
--- a/src/main/java/com/jeonggolee/helpanimal/InitLocalTestData.java
+++ b/src/main/java/com/jeonggolee/helpanimal/InitLocalTestData.java
@@ -1,0 +1,58 @@
+package com.jeonggolee.helpanimal;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Animal;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.AnimalRepository;
+import com.jeonggolee.helpanimal.domain.user.dto.UserSignupDto;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import com.jeonggolee.helpanimal.domain.user.repository.UserRepository;
+import com.jeonggolee.helpanimal.domain.user.service.UserService;
+import com.jeonggolee.helpanimal.domain.user.util.Role;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("local")
+public class InitLocalTestData {
+    private final AnimalRepository animalRepository;
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private static final Role ROLE = Role.USER;
+    private static final String EMAIL = "test@test.com";
+    private static final String PASSWORD = "test_password";
+    private static final String NICKNAME = "test nickname";
+    private static final String IMAGE = "test image";
+    private static final String NAME = "홍길동";
+
+    @PostConstruct
+    public void init() throws Exception {
+        log.info("init");
+        userService.signUpUser(UserSignupDto.builder()
+                .name(NAME)
+                .role(ROLE)
+                .email(EMAIL)
+                .password(PASSWORD)
+                .nickname(NICKNAME)
+                .profileImag(IMAGE)
+                .build());
+
+        User user = userRepository.getById(1L);
+        Animal dog = Animal.builder()
+                .name("DOG")
+                .user(user)
+                .build();
+
+        Animal cat = Animal.builder()
+                .name("CAT")
+                .user(user)
+                .build();
+
+        animalRepository.saveAll(List.of(dog, cat));
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/common/execption/AnimalNotFoundException.java
+++ b/src/main/java/com/jeonggolee/helpanimal/common/execption/AnimalNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jeonggolee.helpanimal.common.execption;
+
+public class AnimalNotFoundException extends RuntimeException{
+    public AnimalNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/common/execption/RecruitmentNotFoundException.java
+++ b/src/main/java/com/jeonggolee/helpanimal/common/execption/RecruitmentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jeonggolee.helpanimal.common.execption;
+
+public class RecruitmentNotFoundException extends RuntimeException{
+    public RecruitmentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/common/handler/CommonExceptionHandler.java
+++ b/src/main/java/com/jeonggolee/helpanimal/common/handler/CommonExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.jeonggolee.helpanimal.common.handler;
 
+import com.jeonggolee.helpanimal.common.execption.AnimalNotFoundException;
+import com.jeonggolee.helpanimal.common.execption.RecruitmentNotFoundException;
 import com.jeonggolee.helpanimal.common.execption.UserNotFoundException;
 import com.jeonggolee.helpanimal.domain.user.exception.ExceptionStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -11,6 +14,27 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class CommonExceptionHandler {
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ExceptionStatus> userNotFoundException(UserNotFoundException e) {
+        ExceptionStatus response = new ExceptionStatus(e.getMessage(), 400);
+        return new ResponseEntity<ExceptionStatus>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionStatus> methodArgumentNotValidExcepton(MethodArgumentNotValidException e) {
+        ExceptionStatus response = new ExceptionStatus(e.getBindingResult()
+                .getAllErrors()
+                .get(0)
+                .getDefaultMessage(), 400);
+        return new ResponseEntity<ExceptionStatus>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AnimalNotFoundException.class)
+    public ResponseEntity<ExceptionStatus> animalNotFoundException(AnimalNotFoundException e) {
+        ExceptionStatus response = new ExceptionStatus(e.getMessage(), 400);
+        return new ResponseEntity<ExceptionStatus>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(RecruitmentNotFoundException.class)
+    public ResponseEntity<ExceptionStatus> recruitmentNotFoundException(RecruitmentNotFoundException e) {
         ExceptionStatus response = new ExceptionStatus(e.getMessage(), 400);
         return new ResponseEntity<ExceptionStatus>(response, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/jeonggolee/helpanimal/config/security/SecurityConfig.java
+++ b/src/main/java/com/jeonggolee/helpanimal/config/security/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/swagger-ui/**").permitAll()
                 .antMatchers("/api/v1/user/login/").anonymous()
                 .antMatchers("/api/v1/user/{email}/").authenticated()
+                .antMatchers("/api/v1/recruitment/**").hasAnyRole("USER","ADMIN")
                 .anyRequest().permitAll()
                 .and()
                 .formLogin().disable()

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentController.java
@@ -1,0 +1,71 @@
+package com.jeonggolee.helpanimal.domain.recruitment.controller;
+
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentRegistDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentUpdateDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentListDto;
+import com.jeonggolee.helpanimal.domain.recruitment.service.RecruitmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class RecruitmentController {
+    private final RecruitmentService recruitmentService;
+
+    /**
+     * 공고 등록
+     */
+    @PostMapping("/api/v1/recruitment")
+    public ResponseEntity<Long> registRecruitment(
+            @RequestBody @Valid RecruitmentRegistDto registDto) throws Exception {
+        return new ResponseEntity<Long>(recruitmentService.registRecruitment(registDto), HttpStatus.CREATED);
+    }
+
+    /**
+     * 공고 전체조회(페이징)
+     */
+    @GetMapping("/api/v1/recruitment")
+    public ResponseEntity<Page<RecruitmentListDto>> getAllRecruitmentList(
+            Pageable pageable) throws Exception {
+        return new ResponseEntity<Page<RecruitmentListDto>>(
+                recruitmentService.getRecriutmentListWithPaging(pageable), HttpStatus.OK);
+    }
+
+    /**
+     * 공고 수정
+     */
+    @PutMapping("/api/v1/recruitment/{id}")
+    public ResponseEntity updateRecruitment(
+            @PathVariable("id") Long id,
+            @RequestBody @Valid RecruitmentUpdateDto updateDto) throws Exception {
+        recruitmentService.updateRecruitment(id,updateDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    /**
+     * 공고 상세조회
+     */
+    @GetMapping("/api/v1/recruitment/{id}")
+    public ResponseEntity<RecruitmentDetailDto> getRecruitmentDetail(
+            @PathVariable("id") Long id) throws Exception {
+        return new ResponseEntity<RecruitmentDetailDto>(
+                recruitmentService.getRecruitmentDetail(id),HttpStatus.OK);
+    }
+
+    /**
+     * 공고 삭제
+     */
+    @DeleteMapping("/api/v1/recruitment/{id}")
+    public ResponseEntity deleteRecruitment(@PathVariable("id") @Valid Long id) throws Exception {
+        recruitmentService.deleteRecruitment(id);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/request/RecruitmentRegistDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/request/RecruitmentRegistDto.java
@@ -1,0 +1,56 @@
+package com.jeonggolee.helpanimal.domain.recruitment.dto.request;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Animal;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentRegistDto {
+    /** 공고 명 */
+    @NotEmpty(message = "공고명을 입력해주세요")
+    private String name;
+    /** 작성자 email */
+    @NotEmpty(message = "작성자 Email이 없습니다.")
+    private String email;
+    /** 본문 */
+    @NotEmpty(message = "본문을 입력해주세요")
+    private String content;
+    /** 동물 */
+    @NotEmpty(message = "봉사구분(동물)이 선택되지 않았습니다.")
+    private String animal;
+    /** 참가자 수 */
+    @NotNull(message = "참가자 수를 입력해주세요")
+    private int participant;
+    /** 공고 구분 */
+    @NotNull(message = "공고 구분을 선택해주세요")
+    private RecruitmentType recruitmentType;
+    /** 채용방법 */
+    @NotNull(message = "채용방법을 선택해주세요")
+    private RecruitmentMethod recruitmentMethod;
+
+    public Recruitment toEntity(User user, Animal animal){
+        return Recruitment.builder()
+                .name(this.name)
+                .content(this.content)
+                .user(user)
+                .animal(animal)
+                .recruitmentType(this.recruitmentType)
+                .recruitmentMethod(this.recruitmentMethod)
+                .participant(this.participant)
+                .build();
+    }
+
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/request/RecruitmentUpdateDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/request/RecruitmentUpdateDto.java
@@ -1,0 +1,30 @@
+package com.jeonggolee.helpanimal.domain.recruitment.dto.request;
+
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentUpdateDto {
+    /* 공고 명 */
+    @NotEmpty(message = "공고 명이 비어있습니다.")
+    private String name;
+    /* 본문 */
+    @NotEmpty(message = "본문이 비어있습니다.")
+    private String content;
+    /* 총 참가 인원 */
+    @NotNull(message = "참가인원이 비어있습니다.")
+    private int participant;
+    /* 첨부파일 사진 URL */
+    @NotEmpty(message = "첨부파일 URl이 비어있습니다.")
+    private String imageUrl;
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentDetailDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentDetailDto.java
@@ -1,0 +1,44 @@
+package com.jeonggolee.helpanimal.domain.recruitment.dto.response;
+
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecruitmentDetailDto {
+    /* 게시글 번호 */
+    private Long id;
+    /* 공고 명 */
+    private String name;
+    /* 공고 구분 */
+    private RecruitmentType recruitmentType;
+    /* 등록자 */
+    private String author;
+    /* 본문 */
+    private String content;
+    /* 봉사 구분 */
+    private String animalType;
+    /* 총 참가 인원 */
+    private int participant;
+    /* 첨부파일 사진 URL */
+    private String imageUrl;
+    /* 채용 방식 */
+    private RecruitmentMethod recruitmentMethod;
+
+    public static RecruitmentDetailDto convertDto(Recruitment recruitment) {
+        return RecruitmentDetailDto.builder()
+                .id(recruitment.getId())
+                .name(recruitment.getName())
+                .recruitmentType(recruitment.getRecruitmentType())
+                .author(recruitment.getUser().getNickname())
+                .content(recruitment.getContent())
+                .animalType(recruitment.getAnimal().getName())
+                .participant(recruitment.getParticipant())
+                .imageUrl(recruitment.getImageUrl())
+                .recruitmentMethod(recruitment.getRecruitmentMethod())
+                .build();
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentListDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentListDto.java
@@ -1,0 +1,35 @@
+package com.jeonggolee.helpanimal.domain.recruitment.dto.response;
+
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentListDto {
+    /* 게시글 번호 */
+    private Long id;
+    /* 공고명 */
+    private String name;
+    /* 공고 구분 */
+    private RecruitmentType recruitmentType;
+    /* 등록자 */
+    private String author;
+    /* 본문 */
+    private String content;
+    /* 봉사 구분 */
+    private String animalType;
+    /* 총 참가 인원 */
+    private int participant;
+    /* 첨부파일 사진 URL */
+    private String imageUrl;
+    /* 채용 방식 */
+    private RecruitmentMethod recruitmentMethod;
+
+
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Recruitment.java
@@ -30,7 +30,7 @@ public class Recruitment extends BaseTimeEntity {
 
     /** 등록자 */
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "author_id")
     private User user;
 
     /** 내용 */
@@ -47,7 +47,7 @@ public class Recruitment extends BaseTimeEntity {
     private int participant;
 
     /** 첨부 이미지 */
-    @Column(nullable = false, length = 500)
+    @Column(nullable = true, length = 500)
     private String imageUrl;
 
     /** 채용 방식 */
@@ -63,6 +63,15 @@ public class Recruitment extends BaseTimeEntity {
         this.name = name;
     }
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
 
+    public void updateParticipant(int participant) {
+        this.participant = participant;
+    }
 
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/exception/RecruitmentNotOwnerException.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/exception/RecruitmentNotOwnerException.java
@@ -1,0 +1,7 @@
+package com.jeonggolee.helpanimal.domain.recruitment.exception;
+
+public class RecruitmentNotOwnerException extends RuntimeException {
+    public RecruitmentNotOwnerException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/exception/handler/RecruitmentExceptionHandler.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/exception/handler/RecruitmentExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.jeonggolee.helpanimal.domain.recruitment.exception.handler;
+
+import com.jeonggolee.helpanimal.domain.recruitment.exception.RecruitmentNotOwnerException;
+import com.jeonggolee.helpanimal.domain.user.exception.ExceptionStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice(basePackages = {"com.jeonggolee.helpanimal.domain.recruitment"})
+public class RecruitmentExceptionHandler {
+    @ExceptionHandler(RecruitmentNotOwnerException.class)
+    public ResponseEntity<ExceptionStatus> recruitmentNotOwnerException(RecruitmentNotOwnerException e) {
+        ExceptionStatus response = new ExceptionStatus(e.getMessage(), 400);
+        return new ResponseEntity<ExceptionStatus>(response, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AnimalRepository extends JpaRepository<Animal,Long> {
-    public Optional<Animal> findByName(String name);
+    Optional<Animal> findByName(String name);
+    Optional<Animal> findByNameAndDeletedAtNull(String name);
 }

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,10 +1,14 @@
 package com.jeonggolee.helpanimal.domain.recruitment.repository;
 
 import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
     public Optional<Recruitment> findByName(String name);
+    public Page<Recruitment> findAllByDeletedAtIsNull(Pageable pageable);
+    public Optional<Recruitment> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentService.java
@@ -1,0 +1,114 @@
+package com.jeonggolee.helpanimal.domain.recruitment.service;
+
+import com.jeonggolee.helpanimal.common.execption.AnimalNotFoundException;
+import com.jeonggolee.helpanimal.common.execption.RecruitmentNotFoundException;
+import com.jeonggolee.helpanimal.common.execption.UserNotFoundException;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentRegistDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentUpdateDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentListDto;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Animal;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.exception.RecruitmentNotOwnerException;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.AnimalRepository;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.RecruitmentRepository;
+import com.jeonggolee.helpanimal.domain.user.dto.UserInfoReadDto;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import com.jeonggolee.helpanimal.domain.user.repository.UserRepository;
+import com.jeonggolee.helpanimal.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecruitmentService {
+    private final RecruitmentRepository recruitmentRepository;
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final AnimalRepository animalRepository;
+    /**
+     * 공고등록
+     */
+    public Long registRecruitment(RecruitmentRegistDto dto) {
+        User author = validateUser(dto.getEmail());
+        Animal animal = validateAnimal(dto.getAnimal());
+        return recruitmentRepository.save(dto.toEntity(author,animal)).getId();
+    }
+
+    /**
+     * 공고 조회 페이징
+     */
+    public Page<RecruitmentListDto> getRecriutmentListWithPaging(Pageable pageable) {
+        return recruitmentRepository.findAllByDeletedAtIsNull(pageable)
+                .map(recruitment -> new RecruitmentListDto().builder()
+                        .id(recruitment.getId())
+                        .name(recruitment.getName())
+                        .recruitmentType(recruitment.getRecruitmentType())
+                        .author(recruitment.getUser().getNickname())
+                        .content(recruitment.getContent())
+                        .animalType(recruitment.getAnimal().getName())
+                        .participant(recruitment.getParticipant())
+                        .imageUrl(recruitment.getImageUrl())
+                        .recruitmentMethod(recruitment.getRecruitmentMethod())
+                        .build());
+    }
+
+    /**
+     * 공고 상세조회
+     */
+    public RecruitmentDetailDto getRecruitmentDetail(Long id) {
+        return RecruitmentDetailDto.convertDto(getRecruitment(id));
+    }
+
+    /**
+     * 공고 수정
+     */
+    public void updateRecruitment(Long id, RecruitmentUpdateDto dto) throws Exception {
+        Recruitment recruitment = getRecruitment(id);
+
+        validateAuthor(recruitment.getUser());
+
+        recruitment.updateRecruitmentName(dto.getName());
+        recruitment.updateContent(dto.getContent());
+        recruitment.updateParticipant(dto.getParticipant());
+        recruitment.updateImageUrl(dto.getImageUrl());
+
+        recruitmentRepository.save(recruitment);
+    }
+
+    /**
+     * 공고 삭제
+     */
+    public void deleteRecruitment(Long id) throws Exception {
+        Recruitment recruitment = getRecruitment(id);
+        validateAuthor(recruitment.getUser());
+        recruitment.delete();
+        recruitmentRepository.save(recruitment);
+    }
+
+    private User validateUser(String email) {
+        return userRepository.findByEmailAndDeletedAtNull(email).orElseThrow(
+                ()-> new UserNotFoundException("해당 회원이 존재하지 않습니다."));
+    }
+
+    private Animal validateAnimal(String animal) {
+        return animalRepository.findByNameAndDeletedAtNull(animal).orElseThrow(
+                ()-> new AnimalNotFoundException("해당 동물은 존재하지 않습니다."));
+    }
+
+    private Recruitment getRecruitment(Long id) {
+        return recruitmentRepository.findById(id).orElseThrow(
+                ()-> new RecruitmentNotFoundException("해당 공고를 찾을 수 없습니다."));
+    }
+
+    private void validateAuthor(User user) throws Exception {
+        UserInfoReadDto userInfoReadDto = userService.userInfoReadDto();
+        if (userInfoReadDto.getUserId() != user.getUserId()) {
+            throw new RecruitmentNotOwnerException("해당 공고의 작성자가 아닙니다.");
+        }
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/user/repository/UserRepository.java
@@ -4,6 +4,8 @@ import com.jeonggolee.helpanimal.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface UserRepository extends JpaRepository<User, Long> , JpaSpecificationExecutor<User> {
+import java.util.Optional;
 
+public interface UserRepository extends JpaRepository<User, Long> , JpaSpecificationExecutor<User> {
+    Optional<User> findByEmailAndDeletedAtNull(String email);
 }

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -1,0 +1,163 @@
+package com.jeonggolee.helpanimal.domain.recruitment.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentRegistDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentUpdateDto;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Animal;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.AnimalRepository;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.RecruitmentRepository;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import com.jeonggolee.helpanimal.domain.user.repository.UserRepository;
+import com.jeonggolee.helpanimal.domain.user.util.Role;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RecruitmentControllerTest {
+    private final String NAME = "테스트공고";
+    private final String EMAIL = "test1@naver.com";
+    private final String CONTENT = "본문";
+    private final String ANIMAL = "DOG";
+    private final int PARTICIPANT = 10;
+    private final RecruitmentMethod RECRUITMENT_METHOD = RecruitmentMethod.CHOICE;
+    private final RecruitmentType RECRUITMENT_TYPE = RecruitmentType.FREE;
+    private static Long RECRUITMENT_ID;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AnimalRepository animalRepository;
+
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    @BeforeAll
+    public void 유저_동물_등록() {
+        User user = initUser();
+        Animal animal = initAnimal(user);
+        initRecruitment(user, animal);
+    }
+
+    private User initUser() {
+        User user = User.builder()
+                .name("테스트")
+                .email(EMAIL)
+                .password("pass")
+                .nickname("닉네임")
+                .profileImage("image")
+                .role(Role.GUEST)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Animal initAnimal(User user) {
+        return animalRepository.save(Animal.builder()
+                .name(ANIMAL)
+                .user(user)
+                .build()
+        );
+    }
+
+    private void initRecruitment(User user, Animal animal) {
+        RECRUITMENT_ID = recruitmentRepository.save(
+                Recruitment.builder()
+                        .name(NAME)
+                        .user(user)
+                        .content(CONTENT)
+                        .animal(animal)
+                        .participant(PARTICIPANT)
+                        .recruitmentMethod(RECRUITMENT_METHOD)
+                        .recruitmentType(RECRUITMENT_TYPE)
+                        .build()).getId();
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    public void 공고등록() throws Exception {
+        RecruitmentRegistDto dto = RecruitmentRegistDto.builder()
+                .name("공고등록_이름")
+                .email(EMAIL)
+                .content(CONTENT)
+                .animal(ANIMAL)
+                .participant(PARTICIPANT)
+                .recruitmentMethod(RECRUITMENT_METHOD)
+                .recruitmentType(RECRUITMENT_TYPE)
+                .build();
+
+        String content = objectMapper.writeValueAsString(dto);
+
+        mvc.perform(MockMvcRequestBuilders.post("/api/v1/recruitment")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)).andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    public void 공고페이징() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.get("/api/v1/recruitment?page=0&size=10&sort=id,desc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    public void 공고수정() throws Exception {
+        RecruitmentUpdateDto dto = RecruitmentUpdateDto.builder()
+                .name("공고명_수정")
+                .content("공고내용_수정")
+                .participant(3)
+                .imageUrl("UPDATE_URL")
+                .build();
+
+        String content = objectMapper.writeValueAsString(dto);
+
+        mvc.perform(MockMvcRequestBuilders.put("/api/v1/recruitment/"+RECRUITMENT_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    public void 공고_상세조회() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.get("/api/v1/recruitment/" + RECRUITMENT_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    public void 공고삭제() throws Exception{
+        mvc.perform(MockMvcRequestBuilders.delete("/api/v1/recruitment/" + RECRUITMENT_ID)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepositoryTest.java
@@ -7,8 +7,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -133,6 +136,22 @@ public class RecruitmentRepositoryTest {
         //then
         Optional<Recruitment> deleteRecruitment = recruitmentRepository.findById(id);
         assertThat(deleteRecruitment.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("공고 페이징")
+    void 공고페이징_삭제된_공고는_조회되지_않는다() {
+        //given
+        Recruitment recruitment = initEntity();
+        Recruitment deletedRecruitment = initEntity();
+        deletedRecruitment.delete();
+        recruitmentRepository.saveAll(List.of(recruitment,deletedRecruitment));
+
+        //when
+        Page<Recruitment> list = recruitmentRepository.findAllByDeletedAtIsNull(PageRequest.of(0,10));
+
+        //then
+        assertThat(list.getTotalElements()).isEqualTo(1L);
     }
 
 }

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentServiceTest.java
@@ -1,0 +1,225 @@
+package com.jeonggolee.helpanimal.domain.recruitment.service;
+
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentRegistDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentUpdateDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentListDto;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Animal;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.AnimalRepository;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.RecruitmentRepository;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import com.jeonggolee.helpanimal.domain.user.repository.UserRepository;
+import com.jeonggolee.helpanimal.domain.user.util.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class RecruitmentServiceTest {
+    @Autowired
+    private RecruitmentService recruitmentService;
+
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AnimalRepository animalRepository;
+
+
+    private final String NAME = "테스트공고";
+    private final String EMAIL = "test1@naver.com";
+    private final String CONTENT = "본문";
+    private final String ANIMAL = "DOG";
+    private final int PARTICIPANT = 10;
+    private final RecruitmentMethod RECRUITMENT_METHOD = RecruitmentMethod.CHOICE;
+    private final RecruitmentType RECRUITMENT_TYPE = RecruitmentType.FREE;
+
+    private User initUser() {
+        User user = User.builder()
+                .name("test")
+                .email(EMAIL)
+                .password("pass")
+                .nickname("닉네임")
+                .profileImage("image")
+                .role(Role.GUEST)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private void initAnimal(User user) {
+        animalRepository.save(Animal.builder()
+                .name(ANIMAL)
+                .user(user)
+                .build()
+        );
+    }
+
+    @Test
+    @DisplayName("공고등록 테스트")
+    public void 공고등록() {
+        //given
+        User user = initUser();
+        initAnimal(user);
+
+        RecruitmentRegistDto dto = RecruitmentRegistDto.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .content(CONTENT)
+                .animal(ANIMAL)
+                .participant(PARTICIPANT)
+                .recruitmentMethod(RECRUITMENT_METHOD)
+                .recruitmentType(RECRUITMENT_TYPE)
+                .build();
+
+        //when
+        recruitmentService.registRecruitment(dto);
+
+        //then
+        Optional<Recruitment> recruitment = recruitmentRepository.findByName(NAME);
+        assertThat(recruitment.isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("공고전체조회 첫페이지 조회 테스트")
+    public void 공고전체조회_페이징() {
+        //given
+        User user = initUser();
+        initAnimal(user);
+        Pageable pageable = PageRequest.of(0,10);
+
+        for (int i = 0; i < 12; i++) {
+            RecruitmentRegistDto dto = RecruitmentRegistDto.builder()
+                    .name(NAME + i)
+                    .email(EMAIL)
+                    .content(CONTENT)
+                    .animal(ANIMAL)
+                    .participant(PARTICIPANT)
+                    .recruitmentType(RECRUITMENT_TYPE)
+                    .recruitmentMethod(RECRUITMENT_METHOD)
+                    .build();
+
+            recruitmentService.registRecruitment(dto);
+
+        }
+        //when
+        Page<RecruitmentListDto> list = recruitmentService.getRecriutmentListWithPaging(pageable);
+        //then
+        assertThat(list.getNumberOfElements()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("공고 상세조회 테스트")
+    public void 공고_상세조회() {
+        //given
+        User user = initUser();
+        initAnimal(user);
+
+        RecruitmentRegistDto dto = RecruitmentRegistDto.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .content(CONTENT)
+                .animal(ANIMAL)
+                .participant(PARTICIPANT)
+                .recruitmentMethod(RECRUITMENT_METHOD)
+                .recruitmentType(RECRUITMENT_TYPE)
+                .build();
+
+        Long id = recruitmentService.registRecruitment(dto);
+
+        //when
+        RecruitmentDetailDto detailDto = recruitmentService.getRecruitmentDetail(id);
+
+        //then
+
+        assertThat(detailDto.getName()).isEqualTo(NAME);
+        assertThat(detailDto.getContent()).isEqualTo(CONTENT);
+        assertThat(detailDto.getAnimalType()).isEqualTo(ANIMAL);
+        assertThat(detailDto.getParticipant()).isEqualTo(PARTICIPANT);
+        assertThat(detailDto.getRecruitmentMethod()).isEqualTo(RECRUITMENT_METHOD);
+        assertThat(detailDto.getRecruitmentType()).isEqualTo(RECRUITMENT_TYPE);
+    }
+
+    @Test
+    @DisplayName("공고 수정 테스트")
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    public void 공고수정() throws Exception{
+        //given
+        User user = initUser();
+        initAnimal(user);
+
+        RecruitmentRegistDto dto = RecruitmentRegistDto.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .content(CONTENT)
+                .animal(ANIMAL)
+                .participant(PARTICIPANT)
+                .recruitmentMethod(RECRUITMENT_METHOD)
+                .recruitmentType(RECRUITMENT_TYPE)
+                .build();
+
+        Long id = recruitmentService.registRecruitment(dto);
+
+        //when
+        RecruitmentUpdateDto updateDto = RecruitmentUpdateDto.builder()
+                .name("UPDATE_NAME")
+                .content("UPDATE_CONTENT")
+                .participant(1)
+                .imageUrl("UPDATE_IMAGE")
+                .build();
+
+
+        recruitmentService.updateRecruitment(id,updateDto);
+        RecruitmentDetailDto detailDto = recruitmentService.getRecruitmentDetail(id);
+
+        //then
+        assertThat(detailDto.getName()).isEqualTo(updateDto.getName());
+        assertThat(detailDto.getContent()).isEqualTo(updateDto.getContent());
+        assertThat(detailDto.getParticipant()).isEqualTo(updateDto.getParticipant());
+        assertThat(detailDto.getImageUrl()).isEqualTo(updateDto.getImageUrl());
+    }
+
+    @Test
+    @DisplayName("공고 삭제 테스트")
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    public void 공고삭제() throws Exception {
+        //given
+        User user = initUser();
+        initAnimal(user);
+
+        RecruitmentRegistDto dto = RecruitmentRegistDto.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .content(CONTENT)
+                .animal(ANIMAL)
+                .participant(PARTICIPANT)
+                .recruitmentMethod(RECRUITMENT_METHOD)
+                .recruitmentType(RECRUITMENT_TYPE)
+                .build();
+
+        Long id = recruitmentService.registRecruitment(dto);
+
+        //when
+        recruitmentService.deleteRecruitment(id);
+        Optional<Recruitment> recruitment = recruitmentRepository.findByIdAndDeletedAtIsNull(id);
+
+        //then
+        assertThat(recruitment.isPresent()).isFalse();
+    }
+}


### PR DESCRIPTION
 * 공고 CRUD Controller, Service, Repository 추가 및 수정
 * 로컬 환경에서 프로젝트 실행 시 Test Data가 생성되어 수월하게 테스트를 진행 할 수 있습니다. 본인 테스트 데이터가 필요한 경우 해당 클래스에 추가해서 사용하면 됩니다.
 * 공고 수정의 경우 공고 종류, 채용방식 같은 경우는 수정 없이 진행하는 방식으로 생각하여 따로 항목을 추가하지 않았습니다.
 * 공고삭제의 경우 softDeleted 방식으로 삭제될 수 있도록 구현 하였습니다.
