### PR TITLE
HA-28 Backend : 참여신청 CRUD, 로그인 시 권한 체크 오류 fix

### DIFF
--- a/src/main/java/com/jeonggolee/helpanimal/common/exception/RecruitmentApplicationNotFoundException.java
+++ b/src/main/java/com/jeonggolee/helpanimal/common/exception/RecruitmentApplicationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jeonggolee.helpanimal.common.exception;
+
+public class RecruitmentApplicationNotFoundException extends RuntimeException{
+    public RecruitmentApplicationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/common/handler/CommonExceptionHandler.java
+++ b/src/main/java/com/jeonggolee/helpanimal/common/handler/CommonExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.jeonggolee.helpanimal.common.handler;
 
 import com.jeonggolee.helpanimal.common.exception.AnimalNotFoundException;
+import com.jeonggolee.helpanimal.common.exception.RecruitmentApplicationNotFoundException;
 import com.jeonggolee.helpanimal.common.exception.RecruitmentNotFoundException;
 import com.jeonggolee.helpanimal.common.exception.UserNotFoundException;
 import com.jeonggolee.helpanimal.domain.user.exception.ExceptionStatus;
@@ -35,6 +36,12 @@ public class CommonExceptionHandler {
 
     @ExceptionHandler(RecruitmentNotFoundException.class)
     public ResponseEntity<ExceptionStatus> recruitmentNotFoundException(RecruitmentNotFoundException e) {
+        ExceptionStatus response = new ExceptionStatus(e.getMessage(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<ExceptionStatus>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(RecruitmentApplicationNotFoundException.class)
+    public ResponseEntity<ExceptionStatus> recruitmentApplicationNotFoundException(RecruitmentApplicationNotFoundException e) {
         ExceptionStatus response = new ExceptionStatus(e.getMessage(), HttpStatus.BAD_REQUEST);
         return new ResponseEntity<ExceptionStatus>(response, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/jeonggolee/helpanimal/config/security/SecurityConfig.java
+++ b/src/main/java/com/jeonggolee/helpanimal/config/security/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/swagger-ui/**").permitAll()
                 .antMatchers("/api/v1/user/login/").anonymous()
                 .antMatchers("/api/v1/user/{email}/").authenticated()
+                .antMatchers("/api/v1/recruitment").hasAnyRole("USER","ADMIN")
                 .antMatchers("/api/v1/recruitment/**").hasAnyRole("USER","ADMIN")
                 .antMatchers("/api/v1/crew/**").authenticated()
                 .anyRequest().permitAll()

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentApplicationController.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentApplicationController.java
@@ -1,0 +1,62 @@
+package com.jeonggolee.helpanimal.domain.recruitment.controller;
+
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentApplicationRequestDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationSearchDto;
+import com.jeonggolee.helpanimal.domain.recruitment.service.RecruitmentApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class RecruitmentApplicationController {
+    private final RecruitmentApplicationService recruitmentApplicationService;
+
+    /**
+     * 참여신청 등록
+     */
+    @PostMapping("/api/v1/recruitment/apply")
+    public ResponseEntity<Long> requestRecruitment(@RequestBody RecruitmentApplicationRequestDto dto) {
+        return new ResponseEntity<Long>(recruitmentApplicationService.requestRecruitment(dto), HttpStatus.CREATED);
+    }
+
+    /**
+     * 공고로 참여신청 목록 조회(페이징)
+     */
+    @GetMapping("/api/v1/recruitment/apply/recruitment/{recruitmentId}")
+    public ResponseEntity<RecruitmentApplicationSearchDto> findByRecruitmentId(@PathVariable("recruitmentId") Long recruitmentId, Pageable pageable) {
+        return new ResponseEntity<RecruitmentApplicationSearchDto>(
+                recruitmentApplicationService.findRecruitmentApplicationByRecruitment(pageable, recruitmentId)
+                , HttpStatus.OK);
+    }
+
+    /**
+     * 해당 유저의 참여신청 목록 조회(페이징)
+     */
+    @GetMapping("/api/v1/recruitment/apply/user/{userId}")
+    public ResponseEntity<RecruitmentApplicationSearchDto> findByUserId(@PathVariable("userId") Long userId, Pageable pageable) {
+        return new ResponseEntity<RecruitmentApplicationSearchDto>(
+                recruitmentApplicationService.findRecruitmentApplicationByUser(pageable, userId)
+                , HttpStatus.OK);
+    }
+
+    /**
+     * 참여신청 삭제
+     */
+    @DeleteMapping("/api/v1/recruitment/apply/{id}")
+    public ResponseEntity deleteRecruitmentApplication(@PathVariable("id") Long id) {
+        recruitmentApplicationService.deleteRecruitmentApplication(id);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    /**
+     * 참여신청 내역 상세조회
+     */
+    @GetMapping("/api/v1/recruitment/apply/{id}")
+    public ResponseEntity<RecruitmentApplicationDetailDto> getApplicationById(@PathVariable("id") Long id) {
+        return new ResponseEntity<RecruitmentApplicationDetailDto>(recruitmentApplicationService.findById(id), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/request/RecruitmentApplicationRequestDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/request/RecruitmentApplicationRequestDto.java
@@ -1,0 +1,16 @@
+package com.jeonggolee.helpanimal.domain.recruitment.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentApplicationRequestDto {
+    private Long recruitmentId;
+    private String email;
+    private String comment;
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentApplicationDetailDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentApplicationDetailDto.java
@@ -1,0 +1,20 @@
+package com.jeonggolee.helpanimal.domain.recruitment.dto.response;
+
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentApplicationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentApplicationDetailDto {
+    private Long id;
+    private Long recruitmentId;
+    private String recruitmentName;
+    private String email;
+    private String comment;
+    private RecruitmentApplicationStatus status;
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentApplicationSearchDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/dto/response/RecruitmentApplicationSearchDto.java
@@ -1,0 +1,18 @@
+package com.jeonggolee.helpanimal.domain.recruitment.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecruitmentApplicationSearchDto {
+    private int numberOfElements;
+    private Long totalElements;
+    private List<RecruitmentApplicationDetailDto> data;
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/Recruitment.java
@@ -57,7 +57,7 @@ public class Recruitment extends BaseTimeEntity {
 
     /** 공고신청내역 */
     @OneToMany(mappedBy = "recruitment")
-    private List<RecruitmentApplicationDetail> recruitmentApplicationDetails;
+    private List<RecruitmentApplication> recruitmentApplications;
 
     public void updateRecruitmentName(String name) {
         this.name = name;

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/RecruitmentApplication.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/entity/RecruitmentApplication.java
@@ -1,6 +1,7 @@
 package com.jeonggolee.helpanimal.domain.recruitment.entity;
 
 import com.jeonggolee.helpanimal.common.eneity.BaseTimeEntity;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentApplicationStatus;
 import com.jeonggolee.helpanimal.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +15,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Builder
 @Entity
-public class RecruitmentApplicationDetail extends BaseTimeEntity {
+public class RecruitmentApplication extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,6 +31,9 @@ public class RecruitmentApplicationDetail extends BaseTimeEntity {
     @Column(length = 50, nullable = false)
     private String comment;
 
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private RecruitmentApplicationStatus status;
     public void updateComment(String comment) {
         this.comment = comment;
     }

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/enums/RecruitmentApplicationStatus.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/enums/RecruitmentApplicationStatus.java
@@ -1,0 +1,18 @@
+package com.jeonggolee.helpanimal.domain.recruitment.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecruitmentApplicationStatus {
+
+    ACCEPTANCE("ACCEPTANCE","수락"),
+    REQUEST("REQUEST","요청"),
+    REJECT("REJECT","거절");
+
+    private final String value;
+    private final String description;
+
+
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/exception/RecruitmentApplicationNotOwnerException.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/exception/RecruitmentApplicationNotOwnerException.java
@@ -1,0 +1,7 @@
+package com.jeonggolee.helpanimal.domain.recruitment.exception;
+
+public class RecruitmentApplicationNotOwnerException extends RuntimeException {
+    public RecruitmentApplicationNotOwnerException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentApplicationDetailRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentApplicationDetailRepository.java
@@ -1,7 +1,0 @@
-package com.jeonggolee.helpanimal.domain.recruitment.repository;
-
-import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplicationDetail;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RecruitmentApplicationDetailRepository extends JpaRepository<RecruitmentApplicationDetail, Long> {
-}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentApplicationRepository.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentApplicationRepository.java
@@ -1,0 +1,94 @@
+package com.jeonggolee.helpanimal.domain.recruitment.repository;
+
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplication;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RecruitmentApplicationRepository extends JpaRepository<RecruitmentApplication, Long> {
+    @Query(
+            "SELECT ra " +
+                    "FROM RecruitmentApplication ra " +
+                    "INNER JOIN ra.user u " +
+                    "     ON ra.deletedAt IS NULL " +
+                    "    AND u.deletedAt IS NULL " +
+                    "WHERE ra.id = :raId " +
+                    "AND   u.userId = :userId "
+    )
+    List<RecruitmentApplication> findByHistory(@Param("raId") Long raId, @Param("userId") Long userId);
+
+    Optional<RecruitmentApplication> findByIdAndUserAndDeletedAtIsNull(Long id, User user);
+
+    Optional<RecruitmentApplication> findByIdAndDeletedAtIsNull(Long id);
+
+    @Query(value =
+            "SELECT new com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto( " +
+                    "ra.id, " +
+                    "r.id, " +
+                    "r.name, " +
+                    "u.email, " +
+                    "ra.comment, " +
+                    "ra.status" +
+                    ") " +
+                    "FROM RecruitmentApplication ra " +
+                    "INNER JOIN User u " +
+                    "       ON ra.user.userId = u.userId " +
+                    "       AND u.deletedAt IS NULL " +
+                    "INNER JOIN Recruitment r " +
+                    "       ON r.id = ra.recruitment.id " +
+                    "       AND r.deletedAt IS NULL " +
+                    "WHERE r.id = :recruitmentId " +
+                    "AND   ra.deletedAt IS NULL ",
+            countQuery =
+                    "SELECT count(ra) " +
+                            "FROM RecruitmentApplication ra " +
+                            "INNER JOIN User u " +
+                            "     ON ra.user.userId = u.userId " +
+                            "     AND u.deletedAt IS NULL " +
+                            "INNER JOIN Recruitment r " +
+                            "     ON r.id = ra.recruitment.id " +
+                            "     AND r.deletedAt IS NULL " +
+                            "WHERE  r.id = :recruitmentId " +
+                            "AND    ra.deletedAt IS NULL")
+    Page<RecruitmentApplicationDetailDto> findRecruitmentApplicationByRecruitment(Pageable pageable, @Param("recruitmentId") Long id);
+
+    @Query(value =
+            "SELECT new com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto( " +
+                    "ra.id, " +
+                    "r.id, " +
+                    "r.name, " +
+                    "u.email, " +
+                    "ra.comment, " +
+                    "ra.status" +
+                    ") " +
+                    "FROM RecruitmentApplication ra " +
+                    "INNER JOIN User u " +
+                    "       ON ra.user.userId = u.userId " +
+                    "       AND u.deletedAt IS NULL " +
+                    "INNER JOIN Recruitment r " +
+                    "       ON r.id = ra.recruitment.id " +
+                    "       AND r.deletedAt IS NULL " +
+                    "WHERE u.userId = :userId " +
+                    "AND   ra.deletedAt IS NULL ",
+            countQuery =
+                    "SELECT count(ra) " +
+                            "FROM RecruitmentApplication ra " +
+                            "INNER JOIN User u " +
+                            "     ON ra.user.userId = u.userId " +
+                            "     AND u.deletedAt IS NULL " +
+                            "INNER JOIN Recruitment r " +
+                            "     ON r.id = ra.recruitment.id " +
+                            "     AND r.deletedAt IS NULL " +
+                            "WHERE u.userId = :userId " +
+                            "AND   ra.deletedAt IS NULL ")
+    Page<RecruitmentApplicationDetailDto> findRecruitmentApplicationByUserId(Pageable pageable, @Param("userId") Long id);
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentApplicationService.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentApplicationService.java
@@ -1,0 +1,134 @@
+package com.jeonggolee.helpanimal.domain.recruitment.service;
+
+import com.jeonggolee.helpanimal.common.exception.RecruitmentApplicationNotFoundException;
+import com.jeonggolee.helpanimal.common.exception.RecruitmentNotFoundException;
+import com.jeonggolee.helpanimal.common.exception.UserNotFoundException;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentApplicationRequestDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationSearchDto;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplication;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentApplicationStatus;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.RecruitmentApplicationRepository;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.RecruitmentRepository;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import com.jeonggolee.helpanimal.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecruitmentApplicationService {
+    private final RecruitmentApplicationRepository recruitmentApplicationRepository;
+    private final UserRepository userRepository;
+    private final RecruitmentRepository recruitmentRepository;
+
+    @Transactional
+    public Long requestRecruitment(RecruitmentApplicationRequestDto dto) {
+        /**
+         * 1. 유저 조회
+         * 2. 공고 조회
+         * 3. 기존 접수내역 삭제처리
+         */
+        User requestUser = findUser(dto.getEmail());
+        Recruitment recruitment = findRecruitment(dto.getRecruitmentId());
+        deleteRecruitmentApplicationHistory(recruitment.getId(), requestUser.getUserId());
+        return recruitmentApplicationRepository.save(RecruitmentApplication.builder()
+                .recruitment(recruitment)
+                .user(requestUser)
+                .comment(dto.getComment())
+                .status(RecruitmentApplicationStatus.REQUEST)
+                .build())
+                .getId();
+    }
+
+    @Transactional
+    public void deleteRecruitmentApplication(Long id) {
+        RecruitmentApplication recruitmentApplication = recruitmentApplicationRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
+                () -> new RecruitmentApplicationNotFoundException("해당 신청내역이 존재하지 않습니다."));
+        recruitmentApplication.delete();
+    }
+
+    public RecruitmentApplicationSearchDto findRecruitmentApplicationByRecruitment(Pageable pageable, Long id) {
+        Page<RecruitmentApplicationDetailDto> resultWithPaging = recruitmentApplicationRepository
+                .findRecruitmentApplicationByRecruitment(pageable, id);
+
+        List<RecruitmentApplicationDetailDto> data = resultWithPaging
+                .map(result -> RecruitmentApplicationDetailDto
+                        .builder()
+                        .id(result.getId())
+                        .recruitmentId(result.getRecruitmentId())
+                        .email(result.getEmail())
+                        .comment(result.getComment())
+                        .status(result.getStatus())
+                        .build())
+                .toList();
+
+        return RecruitmentApplicationSearchDto
+                .builder()
+                .numberOfElements(resultWithPaging.getNumberOfElements())
+                .totalElements(resultWithPaging.getTotalElements())
+                .data(data)
+                .build();
+    }
+
+    public RecruitmentApplicationSearchDto findRecruitmentApplicationByUser(Pageable pageable, Long userId) {
+        Page<RecruitmentApplicationDetailDto> resultWithPaging = recruitmentApplicationRepository
+                .findRecruitmentApplicationByUserId(pageable, userId);
+
+        List<RecruitmentApplicationDetailDto> data = resultWithPaging
+                .map(result -> RecruitmentApplicationDetailDto
+                        .builder()
+                        .id(result.getId())
+                        .recruitmentId(result.getRecruitmentId())
+                        .email(result.getEmail())
+                        .comment(result.getComment())
+                        .status(result.getStatus())
+                        .build())
+                .toList();
+
+        return RecruitmentApplicationSearchDto
+                .builder()
+                .numberOfElements(resultWithPaging.getNumberOfElements())
+                .totalElements(resultWithPaging.getTotalElements())
+                .data(data)
+                .build();
+    }
+
+    private User findUser(String email) {
+        return userRepository.findByEmailAndDeletedAtNull(email).orElseThrow(
+                () -> new UserNotFoundException("존재하지 않는 회원입니다."));
+    }
+
+    private Recruitment findRecruitment(Long recruitmentId) {
+        return recruitmentRepository.findByIdAndDeletedAtIsNull(recruitmentId).orElseThrow(
+                () -> new RecruitmentNotFoundException("해당 공고가 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public void deleteRecruitmentApplicationHistory(Long rid, Long userId) {
+        List<RecruitmentApplication> history = recruitmentApplicationRepository.findByHistory(rid, userId);
+        history.forEach(entities -> entities.delete());
+    }
+
+
+    public RecruitmentApplicationDetailDto findById(Long id) {
+        RecruitmentApplication recruitmentApplication = recruitmentApplicationRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
+                ()-> new RecruitmentApplicationNotFoundException("해당 신청내역이 존재하지 않습니다."));
+        return RecruitmentApplicationDetailDto.builder()
+                .id(recruitmentApplication.getId())
+                .recruitmentId(recruitmentApplication.getRecruitment().getId())
+                .recruitmentName(recruitmentApplication.getRecruitment().getName())
+                .email(recruitmentApplication.getUser().getEmail())
+                .comment(recruitmentApplication.getComment())
+                .status(recruitmentApplication.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/jeonggolee/helpanimal/domain/user/dto/UserInfoReadDto.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/user/dto/UserInfoReadDto.java
@@ -34,6 +34,7 @@ public class UserInfoReadDto {
     private List<CrewMember> crewMemberList;
 
     public UserInfoReadDto(User user) {
+        this.userId = user.getUserId();
         this.email = user.getEmail();
         this.name = user.getName();
         this.nickname = user.getNickname();

--- a/src/main/java/com/jeonggolee/helpanimal/domain/user/service/UserDetailService.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/user/service/UserDetailService.java
@@ -27,7 +27,7 @@ public class UserDetailService implements UserDetailsService {
                 User user = userRepository.findOne(userSpecification.searchWithEmailEqual(email))
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-        return new User(user.getEmail(), user.getPassword(), Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString())));
+        return new User(user.getEmail(), user.getPassword(), Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey())));
     }
 
 }

--- a/src/main/java/com/jeonggolee/helpanimal/domain/user/service/UserService.java
+++ b/src/main/java/com/jeonggolee/helpanimal/domain/user/service/UserService.java
@@ -60,7 +60,7 @@ public class UserService {
         if (!isMatchingPassword) {
             throw new WrongPasswordException("잘못된 패스워드 입니다.");
         }
-        return new JwtTokenDto(provider.generateToken(dto.getEmail(), Collections.singleton(new SimpleGrantedAuthority(user.getRole().toString()))));
+        return new JwtTokenDto(provider.generateToken(dto.getEmail(), Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey()))));
     }
 
     public UserInfoReadDto getUserInfo() {

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentApplicationControllerTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentApplicationControllerTest.java
@@ -1,0 +1,153 @@
+package com.jeonggolee.helpanimal.domain.recruitment.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentApplicationRequestDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationSearchDto;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentApplicationStatus;
+import com.jeonggolee.helpanimal.domain.recruitment.service.RecruitmentApplicationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+public class RecruitmentApplicationControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @MockBean
+    private RecruitmentApplicationService recruitmentApplicationService;
+
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    void 참여신청_등록() throws Exception {
+        RecruitmentApplicationRequestDto dto = RecruitmentApplicationRequestDto.builder()
+                .email("test1@test.com")
+                .comment("comment")
+                .recruitmentId(1L)
+                .build();
+
+        when(recruitmentApplicationService.requestRecruitment(any())).thenReturn(1L);
+
+        String content = objectMapper.writeValueAsString(dto);
+        mvc.perform(MockMvcRequestBuilders.post("/api/v1/recruitment/apply")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    void 참여신청_삭제() throws Exception {
+        doNothing().when(recruitmentApplicationService).deleteRecruitmentApplication(anyLong());
+        mvc.perform(MockMvcRequestBuilders.delete("/api/v1/recruitment/apply/"+1L)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    void 참여신청내역_유저로_조회_페이징() throws Exception {
+
+        when(recruitmentApplicationService.findRecruitmentApplicationByUser(any(),anyLong()))
+                .thenReturn(RecruitmentApplicationSearchDto.builder()
+                        .numberOfElements(0)
+                        .totalElements(10L)
+                        .data(new ArrayList<>())
+                        .build());
+
+        mvc.perform(MockMvcRequestBuilders.get("/api/v1/recruitment/apply/user/1?page=0&size=10")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.numberOfElements").value(0))
+                .andExpect(jsonPath("$.totalElements").value(10L));
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    void 참여신청내역_공고로_조회_페이징() throws Exception {
+
+        when(recruitmentApplicationService.findRecruitmentApplicationByRecruitment(any(),anyLong()))
+                .thenReturn(RecruitmentApplicationSearchDto.builder()
+                        .numberOfElements(0)
+                        .totalElements(10L)
+                        .data(new ArrayList<>())
+                        .build());
+
+        mvc.perform(MockMvcRequestBuilders.get("/api/v1/recruitment/apply/recruitment/1?page=0&size=10")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.numberOfElements").value(0))
+                .andExpect(jsonPath("$.totalElements").value(10L));
+
+    }
+
+    @Test
+    @WithMockUser(username = "test1@naver.com", roles = {"USER"})
+    void 공고_상세조회() throws Exception {
+
+        when(recruitmentApplicationService.findById(anyLong()))
+                .thenReturn(RecruitmentApplicationDetailDto.builder()
+                        .id(1L)
+                        .recruitmentId(1L)
+                        .recruitmentName("TEST 공고")
+                        .email("test1@test.com")
+                        .comment("신청합니다")
+                        .status(RecruitmentApplicationStatus.REQUEST)
+                        .build());
+
+        mvc.perform(MockMvcRequestBuilders.get("/api/v1/recruitment/apply/1")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.recruitmentId").value(1L))
+                .andExpect(jsonPath("$.recruitmentName").value("TEST 공고"))
+                .andExpect(jsonPath("$.email").value("test1@test.com"))
+                .andExpect(jsonPath("$.comment").value("신청합니다"))
+                .andExpect(jsonPath("$.status").value("REQUEST"));
+    }
+}

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/controller/RecruitmentControllerTest.java
@@ -13,6 +13,7 @@ import com.jeonggolee.helpanimal.domain.user.entity.User;
 import com.jeonggolee.helpanimal.domain.user.repository.UserRepository;
 import com.jeonggolee.helpanimal.domain.user.util.Role;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,19 +21,28 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
+import javax.transaction.Transactional;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ActiveProfiles("local")
 public class RecruitmentControllerTest {
     private final String NAME = "테스트공고";
     private final String EMAIL = "test1@naver.com";
     private final String CONTENT = "본문";
-    private final String ANIMAL = "DOG";
+    private final String ANIMAL = "DOG_";
     private final int PARTICIPANT = 10;
     private final RecruitmentMethod RECRUITMENT_METHOD = RecruitmentMethod.CHOICE;
     private final RecruitmentType RECRUITMENT_TYPE = RecruitmentType.FREE;
@@ -52,6 +62,19 @@ public class RecruitmentControllerTest {
 
     @Autowired
     private RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+                .alwaysDo(print())
+                .build();
+    }
+
 
     @BeforeAll
     public void 유저_동물_등록() {

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/AnimalRepositoryTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -12,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 @SpringBootTest
+@ActiveProfiles("local")
 public class AnimalRepositoryTest {
     @Autowired
     private AnimalRepository animalRepository;

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitApplicationDetailRepositoryTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitApplicationDetailRepositoryTest.java
@@ -1,10 +1,14 @@
 package com.jeonggolee.helpanimal.domain.recruitment.repository;
 
-import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplicationDetail;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplication;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -15,12 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 public class RecruitApplicationDetailRepositoryTest {
     @Autowired
-    private RecruitmentApplicationDetailRepository recruitmentApplicationDetailRepository;
+    private RecruitmentApplicationRepository recruitmentApplicationRepository;
 
     private static final String comment = "TEST";
 
-    private RecruitmentApplicationDetail initEntity() {
-        return RecruitmentApplicationDetail.builder()
+    private RecruitmentApplication initEntity() {
+        return RecruitmentApplication.builder()
                 .comment(comment)
                 .build();
     }
@@ -29,24 +33,24 @@ public class RecruitApplicationDetailRepositoryTest {
     @DisplayName("공고신청내역 등록")
     void 공고신청내역등록() {
         //given
-        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
+        RecruitmentApplication recruitmentApplication = initEntity();
 
         //when
-        Long id = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail).getId();
+        Long id = recruitmentApplicationRepository.save(recruitmentApplication).getId();
 
         //then
-        assertThat(recruitmentApplicationDetailRepository.findById(id).isPresent()).isTrue();
+        assertThat(recruitmentApplicationRepository.findById(id).isPresent()).isTrue();
     }
 
     @Test
     @DisplayName("공고신청내역 ID로 조회")
     void 공고신청내역ID로_조회() {
         //given
-        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
-        Long id = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail).getId();
+        RecruitmentApplication recruitmentApplication = initEntity();
+        Long id = recruitmentApplicationRepository.save(recruitmentApplication).getId();
 
         //when
-        Optional<RecruitmentApplicationDetail> findRecruitmentApplicationDetail = recruitmentApplicationDetailRepository.findById(id);
+        Optional<RecruitmentApplication> findRecruitmentApplicationDetail = recruitmentApplicationRepository.findById(id);
 
         //then
         assertThat(findRecruitmentApplicationDetail.isPresent()).isTrue();
@@ -59,7 +63,7 @@ public class RecruitApplicationDetailRepositoryTest {
         Long id = 1000L;
 
         //when
-        Optional<RecruitmentApplicationDetail> recruitmentApplicationDetail = recruitmentApplicationDetailRepository.findById(id);
+        Optional<RecruitmentApplication> recruitmentApplicationDetail = recruitmentApplicationRepository.findById(id);
 
         //then
         assertThat(recruitmentApplicationDetail.isPresent()).isFalse();
@@ -69,29 +73,57 @@ public class RecruitApplicationDetailRepositoryTest {
     @DisplayName("공고신청내역 수정")
     void 공고신청내역수정() {
         //given
-        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
-        recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail);
+        RecruitmentApplication recruitmentApplication = initEntity();
+        recruitmentApplicationRepository.save(recruitmentApplication);
 
         //when
-        recruitmentApplicationDetail.updateComment("수정");
-        RecruitmentApplicationDetail updateRecruitmentApplicationDetail = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail);
+        recruitmentApplication.updateComment("수정");
+        RecruitmentApplication updateRecruitmentApplication = recruitmentApplicationRepository.save(recruitmentApplication);
 
         //then
-        assertThat(updateRecruitmentApplicationDetail.getComment()).isEqualTo(updateRecruitmentApplicationDetail.getComment());
+        assertThat(updateRecruitmentApplication.getComment()).isEqualTo(updateRecruitmentApplication.getComment());
     }
 
     @Test
     @DisplayName("공고신청내역 삭제")
     void 공고신청내역삭제() {
         //given
-        RecruitmentApplicationDetail recruitmentApplicationDetail = initEntity();
-        Long id = recruitmentApplicationDetailRepository.save(recruitmentApplicationDetail).getId();
+        RecruitmentApplication recruitmentApplication = initEntity();
+        Long id = recruitmentApplicationRepository.save(recruitmentApplication).getId();
 
         //when
-        recruitmentApplicationDetailRepository.delete(recruitmentApplicationDetail);
+        recruitmentApplicationRepository.delete(recruitmentApplication);
 
         //then
-        Optional<RecruitmentApplicationDetail> deleteRecruitmentApplicationDetail = recruitmentApplicationDetailRepository.findById(id);
+        Optional<RecruitmentApplication> deleteRecruitmentApplicationDetail = recruitmentApplicationRepository.findById(id);
         assertThat(deleteRecruitmentApplicationDetail.isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("공고내역_공고로_조회_페이징")
+    void 공고내역_공고로_조회_페이징() {
+        //given
+
+        Pageable pageable = PageRequest.of(0, 10);
+        //when
+        Page<RecruitmentApplicationDetailDto> pages = recruitmentApplicationRepository
+                .findRecruitmentApplicationByRecruitment(pageable, 1L);
+        //then
+        assertThat(pages.getNumberOfElements()).isEqualTo(10);
+        assertThat(pages.getTotalElements()).isEqualTo(12L);
+    }
+
+    @Test
+    @DisplayName("공고내역_유저로_조회_페이징")
+    void 공고내역_유저로_조회_페이징() {
+        //given
+
+        Pageable pageable = PageRequest.of(0, 10);
+        //when
+        Page<RecruitmentApplicationDetailDto> pages = recruitmentApplicationRepository
+                .findRecruitmentApplicationByUserId(pageable, 1L);
+        //then
+        assertThat(pages.getNumberOfElements()).isEqualTo(10);
+        assertThat(pages.getTotalElements()).isEqualTo(12L);
     }
 }

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepositoryTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/repository/RecruitmentRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -18,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 @SpringBootTest
+@ActiveProfiles("local")
 public class RecruitmentRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentApplicationServiceTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentApplicationServiceTest.java
@@ -1,0 +1,185 @@
+package com.jeonggolee.helpanimal.domain.recruitment.service;
+
+import com.jeonggolee.helpanimal.domain.recruitment.dto.request.RecruitmentApplicationRequestDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationDetailDto;
+import com.jeonggolee.helpanimal.domain.recruitment.dto.response.RecruitmentApplicationSearchDto;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.Recruitment;
+import com.jeonggolee.helpanimal.domain.recruitment.entity.RecruitmentApplication;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentApplicationStatus;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentMethod;
+import com.jeonggolee.helpanimal.domain.recruitment.enums.RecruitmentType;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.RecruitmentApplicationRepository;
+import com.jeonggolee.helpanimal.domain.recruitment.repository.RecruitmentRepository;
+import com.jeonggolee.helpanimal.domain.user.entity.User;
+import com.jeonggolee.helpanimal.domain.user.repository.UserRepository;
+import com.jeonggolee.helpanimal.domain.user.util.Role;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("local")
+public class RecruitmentApplicationServiceTest {
+    @Autowired
+    private RecruitmentApplicationService recruitmentApplicationService;
+    @Autowired
+    private RecruitmentApplicationRepository recruitmentApplicationRepository;
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private RecruitmentApplication initRecruitmentApplication(Recruitment recruitment, User user, String comment) {
+        return RecruitmentApplication.builder()
+                .recruitment(recruitment)
+                .user(user)
+                .comment(comment)
+                .status(RecruitmentApplicationStatus.REQUEST)
+                .build();
+    }
+
+    private User initUser(String email) {
+        return User.builder()
+                .email(email)
+                .password("PASSWORD")
+                .name("NAME")
+                .nickname("NICKNAME")
+                .profileImage("IMAGE")
+                .role(Role.GUEST)
+                .build();
+    }
+
+    private Recruitment initRecruitment(User user, String name) {
+        return Recruitment.builder()
+                .name(name)
+                .recruitmentType(RecruitmentType.FREE)
+                .content("CONTENT")
+                .participant(1)
+                .user(user)
+                .imageUrl("TEST")
+                .recruitmentMethod(RecruitmentMethod.FIRST_COME)
+                .build();
+    }
+
+    @Test
+    void 공고신청() {
+        //given
+        User user = initUser("EMAIL");
+        Recruitment recruitment = initRecruitment(user, "NAME");
+
+        userRepository.save(user);
+        recruitmentRepository.save(recruitment);
+
+        RecruitmentApplicationRequestDto dto = RecruitmentApplicationRequestDto.builder()
+                .email("EMAIL")
+                .recruitmentId(recruitment.getId())
+                .comment("TEST")
+                .build();
+        //when
+        recruitmentApplicationService.requestRecruitment(dto);
+        //then
+        List<RecruitmentApplication> results = recruitmentApplicationRepository.findAll();
+        assertThat(results.size() > 0).isTrue();
+    }
+
+    @Test
+    void 신청내역_삭제() {
+        //given
+        User user = initUser("EMAIL");
+        Recruitment recruitment = initRecruitment(user, "NAME");
+        RecruitmentApplication recruitmentApplication = initRecruitmentApplication(recruitment, user, "TEST");
+
+        userRepository.save(user);
+        recruitmentRepository.save(recruitment);
+        recruitmentApplicationRepository.save(recruitmentApplication);
+
+        //when
+        recruitmentApplicationService.deleteRecruitmentApplication(recruitmentApplication.getId());
+
+        //then
+        Optional<RecruitmentApplication> result = recruitmentApplicationRepository
+                .findByIdAndUserAndDeletedAtIsNull(recruitmentApplication.getId(), user);
+        assertThat(result.isPresent()).isFalse();
+    }
+
+    @Test
+    void 해당공고_신청내역_조회() {
+        //given
+        User user = initUser("EMAIL");
+        Recruitment recruitment = initRecruitment(user, "NAME");
+
+        userRepository.save(user);
+        recruitmentRepository.save(recruitment);
+
+        for (int i = 0; i < 12; i++) {
+            RecruitmentApplication recruitmentApplication = initRecruitmentApplication(recruitment, user, "TEST" + i);
+            recruitmentApplicationRepository.save(recruitmentApplication);
+
+        }
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createDate").descending());
+        //when
+        RecruitmentApplicationSearchDto dto = recruitmentApplicationService.findRecruitmentApplicationByRecruitment(pageable, recruitment.getId());
+        //then
+        assertThat(dto.getNumberOfElements()).isEqualTo(10);
+        assertThat(dto.getTotalElements()).isEqualTo(12L);
+    }
+
+    @Test
+    void 해당유저_신청내역_조회() {
+        //given
+        User user = initUser("EMAIL");
+        List<Recruitment> recruitments = new ArrayList<>();
+        userRepository.save(user);
+        for (int i = 0; i < 12; i++) {
+            Recruitment recruitment = initRecruitment(user, "NAME" + i);
+            recruitmentRepository.save(recruitment);
+            recruitments.add(recruitment);
+        }
+        for (Recruitment recruitment : recruitments) {
+            RecruitmentApplication recruitmentApplication = initRecruitmentApplication(recruitment, user, "TEST");
+            recruitmentApplicationRepository.save(recruitmentApplication);
+        }
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createDate").descending());
+        //when
+        RecruitmentApplicationSearchDto dto = recruitmentApplicationService.findRecruitmentApplicationByUser(pageable, user.getUserId());
+        //then
+        assertThat(dto.getNumberOfElements()).isEqualTo(10);
+        assertThat(dto.getTotalElements()).isEqualTo(12L);
+    }
+
+    @Test
+    void 참여신청_상세조회() {
+        //given
+        User user = initUser("EMAIL");
+        Recruitment recruitment = initRecruitment(user, "NAME");
+
+        userRepository.save(user);
+        recruitmentRepository.save(recruitment);
+
+        RecruitmentApplication recruitmentApplication = initRecruitmentApplication(recruitment, user,"COMMENT");
+        Long requestId = recruitmentApplicationRepository.save(recruitmentApplication).getId();
+
+        //when
+        RecruitmentApplicationDetailDto result = recruitmentApplicationService.findById(requestId);
+
+        //then
+        assertThat(result.getRecruitmentName()).isEqualTo(recruitment.getName());
+        assertThat(result.getEmail()).isEqualTo(user.getEmail());
+        assertThat(result.getComment()).isEqualTo("COMMENT");
+
+    }
+}

--- a/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/jeonggolee/helpanimal/domain/recruitment/service/RecruitmentServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 
 import javax.transaction.Transactional;
 import java.util.Optional;
@@ -29,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("local")
 public class RecruitmentServiceTest {
     @Autowired
     private RecruitmentService recruitmentService;


### PR DESCRIPTION
* 참여신청 CRUD API를 개발했습니다. 인원수 제한 시 처리되는 로직이나 기타 비즈니스 로직은 추 후 개발 예정입니다.
* 권한 설정 이후 403 처리 되던 이슈를 user.getRole().getKey()를 사용하여 해결하였습니다.
* 테스트 클래스에 @ActiveProfile("local") 을 붙여줘야 할 것 같습니다. 
* 참여신청 endpoint 설계 중 너무 길어져서 부득이하게 줄였습니다.  